### PR TITLE
Ensure gallery image titles aren't clipped in the interface

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -9,8 +9,6 @@
     padding-left: 20px;
 }
 
-.file-picker-select-group {}
-
 iframe {
     display: none;
     left: 100%;
@@ -277,4 +275,47 @@ html {
 
 .blocked {
     pointer-events: none;
+}
+
+/**
+ * When we changing image title only in MS Edge and IE 11 default layout breaks.
+ * Because of that I were diceded to change layout only for thouse two browsers.
+ *   
+ * MS Edge layout
+*/
+@supports (-ms-ime-align: auto) {
+
+    .holder {
+        overflow-x: hidden;
+    }
+    .item-holder:nth-child(3n+2) .edit-image-title {
+        left: calc(-16vw + -70%);
+    }
+    .item-holder:nth-child(3n+3) .edit-image-title {
+        left: calc(-75.1vw + 33%);
+    }
+    .edit-image-title {
+        left: -22px;
+        padding-left: 35px;
+        width: 95vw;
+    }
+}
+
+/* IE11 layout */
+
+@media screen and (-ms-high-contrast: none) {
+
+    .holder {
+        overflow-x: hidden;
+    }
+    .item-holder:nth-child(3n+2) .edit-image-title {
+        left: calc(-13vw + -70%);
+    }
+    .item-holder:nth-child(3n+3) .edit-image-title {
+        left: calc(-75vw + 33%);
+    }
+    .edit-image-title {
+        padding-left: 40px;
+        width: 95vw;
+    }
 }

--- a/css/interface.css
+++ b/css/interface.css
@@ -277,12 +277,7 @@ html {
     pointer-events: none;
 }
 
-/**
- * When we changing image title only in MS Edge and IE 11 default layout breaks.
- * Because of that I were diceded to change layout only for thouse two browsers.
- *   
- * MS Edge layout
-*/
+/* MS Edge layout */
 @supports (-ms-ime-align: auto) {
 
     .holder {

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -7,9 +7,9 @@ this["Fliplet"]["Widget"]["Templates"]["templates.image"] = Handlebars.template(
 },"3":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return container.escapeExpression(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"title","hash":{},"data":data}) : helper)));
+  return container.escapeExpression(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"title","hash":{},"data":data}) : helper)));
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "<div class=\"col-xs-4 col-sm-3 col-md-2 item-holder file image\" data-file-id=\""
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue

https://github.com/Fliplet/fliplet-studio/issues/3118

## Description

Add CSS rules for MS Edge and IE11 to correct the display of the image title.

## Screenshots/screencasts

![edge-3118](https://user-images.githubusercontent.com/53430352/62856320-41e84680-bcfd-11e9-9b4a-ba63650418bb.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes

In order to fix the image title view in Edge and IE11 used special rules to define when a user using Edge or IE11 browser.