### PR TITLE
Fixes an issue where users can't scroll the gallery interface

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -100,7 +100,8 @@ html {
 
 #app {
     height: 100vh;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     max-height: 100vh;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
@squallstar @tonytlwu

## Issue
ref Fliplet/fliplet-studio#4621

## Description
**Fixed behavior**: The user was unable to scroll.
Changed overflow properties.

## Screenshots/screencasts
![Scroll demo (online-video-cutter com)](https://user-images.githubusercontent.com/52824207/62864590-cf836080-bd14-11e9-9898-4f3db17d8fd4.gif)


## Backward compatibility
This change is fully backward compatible.
