### PR TITLE
Stops UI from moving around when setting gallery titles

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -198,7 +198,7 @@ html {
 }
 
 .edit-image-title {
-    width: 100vw;
+    width: 95vw;
     position: relative;
     box-sizing: border-box;
     top: 0;
@@ -211,11 +211,11 @@ html {
 }
 
 .item-holder:nth-child(3n+2) .edit-image-title {
-    left: calc(-15.4vw + -70%);
+    left: calc(-15vw + -70%);
 }
 
 .item-holder:nth-child(3n+3) .edit-image-title {
-    left: calc(-76.7vw + 33%);
+    left: calc(-74.7vw + 33%);
 }
 
 .edit-title-section {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue

https://github.com/Fliplet/fliplet-studio/issues/3118
https://github.com/Fliplet/fliplet-studio/issues/3117

## Description

Fixed issue with the title image when multiple images selected.
Also, removed unneeded scroll in Edge when the gallery is loaded. 

## Screenshots/screencasts
![3117-Gallary-Fix](https://user-images.githubusercontent.com/53430352/63173996-be568e80-c049-11e9-9e93-dfc69fd19ce3.gif)
![3118-Gallary-fix](https://user-images.githubusercontent.com/53430352/63174017-c57d9c80-c049-11e9-8cd2-20b27116155e.gif)


## Backward compatibility

This change is fully backward compatible.

