### PR TITLE
Title will be stored to metadata and then get restored

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -297,18 +297,21 @@ function onInputChange() {
 }
 
 function changeImageTitle() {
-  if (!selectedImage) return;
+  if (!selectedImage) {
+    return;
+  }
+
   selectedImage.title = $editInput.val() ? $editInput.val() : '';
   $el = $($('div.image-library').children()[imageForEditIndex]).find('.title-text');
   selectedImage.title ?
     $el.removeClass('title-default-text').text(selectedImage.title) :
     $el.text('').addClass('title-default-text');
+  updateTitle(imageForEditIndex);
 }
 
 function onEditClose(e) {
   if(e) e.preventDefault();
 
-  updateTitle(imageForEditIndex);
   imageForEditIndex = null;
   $editImageTitle.detach();
   changeDragging(true);

--- a/js/interface.js
+++ b/js/interface.js
@@ -252,7 +252,7 @@ function updateTitle(index) {
   if (newImage) {
     newImage.title = selectedImage.title;
   } else {
-    data.imagesMetadata.push({title: selectedImage.title});
+    data.imagesMetadata.push({ title: selectedImage.title });
   }
 }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5986

## Description
On saving title it will be also saved to metadata. When opening gallery component titles will be restored and assigned to images by index.

## Screenshots/screencasts
https://streamable.com/fl19u6

## Backward compatibility
This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii 