### PR TITLE
Images are not duplicated when changing gallery appearance

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -6,6 +6,7 @@ Fliplet.Widget.instance('image-gallery', function (data) {
   function initGallery(options) {
     var $wall = $(wallSelector);
     var $bricks = $();
+    options = options || {};
 
     if (options.appendImages) {
       // Update remote image URLs to authenticated URLs
@@ -24,7 +25,8 @@ Fliplet.Widget.instance('image-gallery', function (data) {
         $brick.append($img);
         $bricks = $bricks.add($brick);
       });
-        $wall.append($bricks);
+
+      $wall.append($bricks);
     }
 
     var wall = new Freewall(wallSelector);
@@ -103,7 +105,7 @@ Fliplet.Widget.instance('image-gallery', function (data) {
 
   // Appearance change Hook
   Fliplet.Hooks.on('appearanceChanged', function () {
-    initGallery({ appendImages: false});
+    initGallery();
   });
 
   Fliplet().then(function () {

--- a/js/build.js
+++ b/js/build.js
@@ -3,11 +3,11 @@ Fliplet.Widget.instance('image-gallery', function (data) {
   var photoswipeTemplate = Fliplet.Widget.Templates['templates.photoswipe'];
   var wallSelector = '[data-image-gallery-id=' + data.id + '] .wall:not("[data-mce-bogus] [data-image-gallery-id=' + data.id + '] .wall")';
 
-  function initGallery(source) {
+  function initGallery(options) {
     var $wall = $(wallSelector);
     var $bricks = $();
 
-    if (source !== 'appearance') {
+    if (options.appendImages) {
       // Update remote image URLs to authenticated URLs
       _.forEach(data.images, function (image, index) {
         var $img = $('<img />');
@@ -103,10 +103,10 @@ Fliplet.Widget.instance('image-gallery', function (data) {
 
   // Appearance change Hook
   Fliplet.Hooks.on('appearanceChanged', function () {
-    initGallery('appearance');
+    initGallery({ appendImages: false});
   });
 
   Fliplet().then(function () {
-    initGallery();
+    initGallery({ appendImages: true });
   });
 });

--- a/js/build.js
+++ b/js/build.js
@@ -6,6 +6,7 @@ Fliplet.Widget.instance('image-gallery', function (data) {
   function initGallery(options) {
     var $wall = $(wallSelector);
     var $bricks = $();
+
     options = options || {};
 
     if (options.appendImages) {

--- a/js/build.js
+++ b/js/build.js
@@ -3,27 +3,29 @@ Fliplet.Widget.instance('image-gallery', function (data) {
   var photoswipeTemplate = Fliplet.Widget.Templates['templates.photoswipe'];
   var wallSelector = '[data-image-gallery-id=' + data.id + '] .wall:not("[data-mce-bogus] [data-image-gallery-id=' + data.id + '] .wall")';
 
-  function initGallery() {
+  function initGallery(source) {
     var $wall = $(wallSelector);
     var $bricks = $();
 
-    // Update remote image URLs to authenticated URLs
-    _.forEach(data.images, function (image, index) {
-      var $img = $('<img />');
+    if (source !== 'appearance') {
+      // Update remote image URLs to authenticated URLs
+      _.forEach(data.images, function (image, index) {
+        var $img = $('<img />');
 
-      image.url = Fliplet.Media.authenticate(image.url);
-      $img.on('load', function() {
-        reloadWall();
+        image.url = Fliplet.Media.authenticate(image.url);
+        $img.on('load', function() {
+          reloadWall();
+        });
+        $img.attr('src', image.url);
+        $img.attr('alt', image.title);
+
+        var $brick = $('<div class="brick"></div>');
+
+        $brick.append($img);
+        $bricks = $bricks.add($brick);
       });
-      $img.attr('src', image.url);
-      $img.attr('alt', image.title);
-
-      var $brick = $('<div class="brick"></div>');
-
-      $brick.append($img);
-      $bricks = $bricks.add($brick);
-    });
-    $wall.append($bricks);
+        $wall.append($bricks);
+    }
 
     var wall = new Freewall(wallSelector);
 
@@ -101,7 +103,7 @@ Fliplet.Widget.instance('image-gallery', function (data) {
 
   // Appearance change Hook
   Fliplet.Hooks.on('appearanceChanged', function () {
-    initGallery();
+    initGallery('appearance');
   });
 
   Fliplet().then(function () {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5974

## Description
Images were duplicated because the whole init gallery was called every time appearance changed.

## Screenshots/screencasts
![gallery-theme (1)](https://user-images.githubusercontent.com/52824207/79216459-db9c6080-7e55-11ea-94da-570280160fdb.gif)

## Backward compatibility
This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii 