### PR TITLE
Restored metadata is saved to preview

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -50,6 +50,8 @@ function restoreFromMetadata() {
       data.images[index].title = elem.title;
     });
   }
+
+  savePreview();
 }
 
 function editImageTitleBinding(e) {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#5986

## Description
Titles will be saved to preview to correctly display titles in preview mode.

## Screencast
https://streamable.com/o1i2t8

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko