### PR TITLE
[Fix] Gallery images are not duplicated when dropping another component

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -27,6 +27,7 @@ Fliplet.Widget.instance('image-gallery', function(data) {
         $bricks = $bricks.add($brick);
       });
 
+      $wall.empty();
       $wall.append($bricks);
     }
 


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5974

## Description
Before we append images new images, we clear wall container. 

## Screencast
https://streamable.com/h79dnw

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko